### PR TITLE
Soporte para la nueva version del Home de Platzi

### DIFF
--- a/PlatziModoCine.js
+++ b/PlatziModoCine.js
@@ -1,51 +1,213 @@
-if (
+console.log("Carga Platzi Modo Cine");
+window.modoCineActivado = false;
+window.retries = 0;
+window.currentURL = window.location.href;
+let modoCine = localStorage.getItem("modoCine");
+window.modoCine = modoCine != null ? Boolean(Number(modoCine)) : false;
+
+window.addEventListener("popstate", function (event) {
+  console.log(
+    "%cPlatzi Modo Cine: Cambio de página.",
+    "font-size: 20px; color: blue;"
+  );
+  window.modoCineActivado = false;
+  window.retries = 0;
+});
+// Creamos una instancia de un objeto MutationObserver y pasamos una función
+// que se ejecutará cuando las mutaciones sean observadas
+window.addEventListener("load", function (event) {
+  this.setTimeout(() => {
+    console.log("Platzi Modo Cine: Cargando...");
+    start();
+    var observer = new MutationObserver(function (mutations) {
+      console.log("Platzi Modo Cine: Cambio detectado.");
+      setTimeout(() => {
+        console.log("llamando Start");
+        start();
+      }, 100);
+      mutations.forEach(function (mutation) {
+        // console.log("mutation:", mutation);
+        // Tu código para manejar las mutaciones va aquí.
+        // Puede ser una llamada a otra función o alguna lógica de ejecución.
+      });
+    });
+
+    // Seleccionamos el objetivo de nuestra observación
+    let target = document.querySelector("#MainLayout");
+    // var target = document.querySelector(".VideoPlayer");
+    let targetVideo = document.querySelector("video-js");
+
+    // Creamos un objeto de configuración con los tipos de mutación que nos gustaría observar
+    var config = {
+      attributes: true,
+      childList: true,
+      subtree: false, // Omitir o configurar como `false` si no deseas observar las mutaciones en los descendientes del objetivo.
+    };
+
+    // Llamamos al método observe() y pasamos el objeto target y el objeto de configuración
+    observer.observe(target, config);
+    observer.observe(targetVideo, config);
+  }, 1000);
+});
+
+function start() {
+  // TODO: Detectar la version del tipo de video segun los elementos que se encuentren en la pagina
+  if (window.currentURL !== window.location.href) {
+    console.log("%cCambio de URL.....", "font-size: 18px; color: blue;");
+    window.modoCineActivado = false;
+    window.retries = 0;
+    window.currentURL = window.location.href;
+  }
+  if (
     // Valida que haya un reproductor de video de Platzi en la página
-    document.querySelector(".MaterialView-video-item") &&
-    document.querySelector(".MaterialView")
-) {
+    (document.querySelector(".MaterialView-video-item") ||
+      document.querySelector(".MaterialView") ||
+      document.querySelector(".MaterialView-content-wrapper")) &&
+    !window.modoCineActivado
+  ) {
     console.log("Platzi Modo Cine: Si hay video.");
-    (function platziModoCine() {
+    let isNewHome = detectarVersionHome();
+    function detectarVersionHome() {
+      // Detecta si es la versión Home de Platzi o el New Home
+      const url = window.location.href;
+      const versionHome = url.includes("new-home");
+      return versionHome;
+    }
+    try {
+      (function platzimodoCineActivado() {
         // Variables para modificar los elementos
-        const container = document.querySelector(".MaterialView");
-        const controlsContainer = document.querySelector(".vjs-control-bar");
-        const videoContainer = document.querySelector(
-            ".MaterialView-video-item"
+        const container = getContainer();
+        const controlsContainer = getControlsContainer();
+        const videoContainer = getVideoContainer();
+
+        // const video = document.querySelector(
+        //   "div.layout_Classes-main-video__11pSj"
+        // );
+        // const player = document.querySelector("#vjs_video_3");
+        // const layout = document.querySelector(".layout_Classes___fdRT");
+        const mainLayout = document.querySelector(
+          ".layout_Classes-main__Vsq6a"
         );
+
+        // const defaultVideoHeight = video.style.height;
+        // const defaultPlayerMaxHeight = player.style.maxHeight;
+        // const defaultLayoutGridTemplateRows = layout.style.gridTemplateRows;
+        const defaultMainLayoutGridTemplateRows = mainLayout.style.gridColumn;
+
         // Variable para cambiar entre modos
-        let cine = false;
+        // window.modoCine = false;
 
         // Variables para capturar el estado por defecto, el Modo Cine "off"
         const defaultColumnas = container.style.gridTemplateColumns;
         const defaultAreas = container.style.gridTemplateAreas;
         const defaultDisplay = container.style.display;
         const defaultMaxWidth = videoContainer.style.maxWidth;
-
+        window.modoCineActivado = true;
         // Crear y poner el botón de Modo Cine
         let botonCine = document.createElement("button");
         botonCine.type = "button";
-        botonCine.innerText = "Modo Cine";
+        botonCine.className = "platzi-modo-cine";
+        botonCine.innerText = `Modo Cine ${Boolean(window.modoCine) ? "On" : "Off"}`;
         controlsContainer.appendChild(botonCine);
         botonCine.style.cursor = "pointer";
         botonCine.addEventListener("click", cambioModo);
 
         function cambioModo() {
-            cine ? modoNormal() : modoCine();
-            cine = !cine;
+          console.log("Platzi Modo Cine: Cambio de modo.");
+          window.modoCine ? modoNormal() : modoCineActivado();
+          window.modoCine = !window.modoCine;
+          botonCine.innerText = `Modo Cine ${Boolean(window.modoCine) ? "On" : "Off"}`;
+          localStorage.setItem("modoCine", Number(window.modoCine));
         }
 
-        function modoCine() {
+        function modoCineActivado() {
+          if (isNewHome) {
+            //   video.style.height = "1100px";
+            //   player.style.maxHeight = "980px";
+            //   layout.style.gridTemplateRows = "1100px 1fr";
+            mainLayout.style.gridColumn = "1/3";
+          } else {
             container.style.gridTemplateColumns = "1fr";
             container.style.gridTemplateAreas = '"video" "content" "community"';
             container.style.display = "grid";
             videoContainer.style.maxWidth = "100vw";
+          }
         }
         function modoNormal() {
+          if (isNewHome) {
+            // video.style.height = defaultVideoHeight;
+            // player.style.maxHeight = defaultPlayerMaxHeight;
+            // layout.style.gridTemplateRows = defaultLayoutGridTemplateRows;
+            mainLayout.style.gridColumn = defaultMainLayoutGridTemplateRows;
+          } else {
             container.style.gridTemplateColumns = defaultColumnas;
             container.style.gridTemplateAreas = defaultAreas;
             container.style.display = defaultDisplay;
             videoContainer.style.maxWidth = defaultMaxWidth;
+          }
         }
-    })();
-} else {
+
+        function validarBotonmodoCineActivadoAgregado() {
+          // Valida si el botón de Modo Cine ya fue agregado
+          const botonmodoCineActivado =
+            document.querySelector(".platzi-modo-cine");
+          return Boolean(botonmodoCineActivado);
+        }
+        if (validarBotonmodoCineActivadoAgregado()) {
+          console.log(
+            `Platzi Modo Cine: Botón agregado. restaurando valor Anterior ${window.modoCine}`
+          );
+          window.modoCine ? modoCineActivado() : modoNormal();
+        } else {
+          window.modoCineActivado = false;
+          setTimeout(() => {
+            start();
+          }, 100);
+        }
+      })();
+    } catch (error) {
+      console.error("Ocurrio un error", error);
+    }
+    function getContainer() {
+      let selector = "";
+      if (isNewHome) {
+        selector = ".MaterialView-content-wrapper";
+      } else {
+        selector = ".MaterialView";
+      }
+      return document.querySelector(selector);
+    }
+
+    function getControlsContainer() {
+      let selector = "";
+      if (isNewHome) {
+        selector = ".vjs-control-bar";
+      } else {
+        selector = ".vjs-control-bar";
+      }
+      return document.querySelector(selector);
+    }
+
+    function getVideoContainer() {
+      let selector = "";
+      if (isNewHome) {
+        selector = ".MaterialView-content-wrapper";
+      } else {
+        selector = ".MaterialView-video-item";
+      }
+      return document.querySelector(selector);
+    }
+  } else if (!window.modoCineActivado) {
     console.log("Platzi Modo Cine: No hay video.");
+    console.log(`Reintentando... ${window.retries}`);
+    if (window.retries <= 3) {
+      console.log("llamando Start setTimeout");
+      window.retries += 1;
+      setTimeout(() => {
+        console.log(`Platzi Modo Cine: Retrying... ${window.retries}`);
+        start();
+      }, 1000);
+    }
+  }
 }
+//

--- a/PlatziModoCine.js
+++ b/PlatziModoCine.js
@@ -1,40 +1,25 @@
-console.log("Carga Platzi Modo Cine");
+// configurando variables de inicialización
 window.modoCineActivado = false;
 window.retries = 0;
 window.currentURL = window.location.href;
 let modoCine = localStorage.getItem("modoCine");
 window.modoCine = modoCine != null ? Boolean(Number(modoCine)) : false;
 
-window.addEventListener("popstate", function (event) {
-  console.log(
-    "%cPlatzi Modo Cine: Cambio de página.",
-    "font-size: 20px; color: blue;"
-  );
-  window.modoCineActivado = false;
-  window.retries = 0;
-});
 // Creamos una instancia de un objeto MutationObserver y pasamos una función
 // que se ejecutará cuando las mutaciones sean observadas
 window.addEventListener("load", function (event) {
   this.setTimeout(() => {
-    console.log("Platzi Modo Cine: Cargando...");
+    // console.log("Platzi Modo Cine: Cargando...");
     start();
     var observer = new MutationObserver(function (mutations) {
-      console.log("Platzi Modo Cine: Cambio detectado.");
+      // console.log("Platzi Modo Cine: Cambio detectado.");
       setTimeout(() => {
         console.log("llamando Start");
         start();
       }, 100);
-      mutations.forEach(function (mutation) {
-        // console.log("mutation:", mutation);
-        // Tu código para manejar las mutaciones va aquí.
-        // Puede ser una llamada a otra función o alguna lógica de ejecución.
-      });
     });
 
-    // Seleccionamos el objetivo de nuestra observación
     let target = document.querySelector("#MainLayout");
-    // var target = document.querySelector(".VideoPlayer");
     let targetVideo = document.querySelector("video-js");
 
     // Creamos un objeto de configuración con los tipos de mutación que nos gustaría observar
@@ -51,15 +36,13 @@ window.addEventListener("load", function (event) {
 });
 
 function start() {
-  // TODO: Detectar la version del tipo de video segun los elementos que se encuentren en la pagina
   if (window.currentURL !== window.location.href) {
-    console.log("%cCambio de URL.....", "font-size: 18px; color: blue;");
     window.modoCineActivado = false;
     window.retries = 0;
     window.currentURL = window.location.href;
   }
   if (
-    // Valida que haya un reproductor de video de Platzi en la página
+    // Valida que haya un reproductor de video de Platzi en la página y que el Modo Cine no esté activado
     (document.querySelector(".MaterialView-video-item") ||
       document.querySelector(".MaterialView") ||
       document.querySelector(".MaterialView-content-wrapper")) &&
@@ -80,51 +63,39 @@ function start() {
         const controlsContainer = getControlsContainer();
         const videoContainer = getVideoContainer();
 
-        // const video = document.querySelector(
-        //   "div.layout_Classes-main-video__11pSj"
-        // );
-        // const player = document.querySelector("#vjs_video_3");
-        // const layout = document.querySelector(".layout_Classes___fdRT");
         const mainLayout = document.querySelector(
           ".layout_Classes-main__Vsq6a"
         );
 
-        // const defaultVideoHeight = video.style.height;
-        // const defaultPlayerMaxHeight = player.style.maxHeight;
-        // const defaultLayoutGridTemplateRows = layout.style.gridTemplateRows;
         const defaultMainLayoutGridTemplateRows = mainLayout.style.gridColumn;
-
-        // Variable para cambiar entre modos
-        // window.modoCine = false;
 
         // Variables para capturar el estado por defecto, el Modo Cine "off"
         const defaultColumnas = container.style.gridTemplateColumns;
         const defaultAreas = container.style.gridTemplateAreas;
         const defaultDisplay = container.style.display;
         const defaultMaxWidth = videoContainer.style.maxWidth;
+
         window.modoCineActivado = true;
-        // Crear y poner el botón de Modo Cine
+
         let botonCine = document.createElement("button");
         botonCine.type = "button";
         botonCine.className = "platzi-modo-cine";
-        botonCine.innerText = `Modo Cine ${Boolean(window.modoCine) ? "On" : "Off"}`;
+        let estadoTexto = Boolean(window.modoCine) ? "On" : "Off"
+        botonCine.innerText = `Modo Cine ${estadoTexto}`;
         controlsContainer.appendChild(botonCine);
         botonCine.style.cursor = "pointer";
         botonCine.addEventListener("click", cambioModo);
 
         function cambioModo() {
-          console.log("Platzi Modo Cine: Cambio de modo.");
           window.modoCine ? modoNormal() : modoCineActivado();
           window.modoCine = !window.modoCine;
-          botonCine.innerText = `Modo Cine ${Boolean(window.modoCine) ? "On" : "Off"}`;
+          let estadoTexto = Boolean(window.modoCine) ? "On" : "Off";
+          botonCine.innerText = `Modo Cine ${estadoTexto}`;
           localStorage.setItem("modoCine", Number(window.modoCine));
         }
 
         function modoCineActivado() {
           if (isNewHome) {
-            //   video.style.height = "1100px";
-            //   player.style.maxHeight = "980px";
-            //   layout.style.gridTemplateRows = "1100px 1fr";
             mainLayout.style.gridColumn = "1/3";
           } else {
             container.style.gridTemplateColumns = "1fr";
@@ -135,9 +106,6 @@ function start() {
         }
         function modoNormal() {
           if (isNewHome) {
-            // video.style.height = defaultVideoHeight;
-            // player.style.maxHeight = defaultPlayerMaxHeight;
-            // layout.style.gridTemplateRows = defaultLayoutGridTemplateRows;
             mainLayout.style.gridColumn = defaultMainLayoutGridTemplateRows;
           } else {
             container.style.gridTemplateColumns = defaultColumnas;
@@ -147,26 +115,21 @@ function start() {
           }
         }
 
-        function validarBotonmodoCineActivadoAgregado() {
-          // Valida si el botón de Modo Cine ya fue agregado
+        function validarBotonModoCineActivadoAgregado() {
           const botonmodoCineActivado =
             document.querySelector(".platzi-modo-cine");
           return Boolean(botonmodoCineActivado);
         }
-        if (validarBotonmodoCineActivadoAgregado()) {
-          console.log(
-            `Platzi Modo Cine: Botón agregado. restaurando valor Anterior ${window.modoCine}`
-          );
+
+        if (validarBotonModoCineActivadoAgregado()) {
           window.modoCine ? modoCineActivado() : modoNormal();
         } else {
           window.modoCineActivado = false;
-          setTimeout(() => {
-            start();
-          }, 100);
+          setTimeout(() => start(), 100);
         }
       })();
     } catch (error) {
-      console.error("Ocurrio un error", error);
+      console.error("Ocurrio un error en Platzi Modo Cine", error);
     }
     function getContainer() {
       let selector = "";
@@ -198,16 +161,11 @@ function start() {
       return document.querySelector(selector);
     }
   } else if (!window.modoCineActivado) {
-    console.log("Platzi Modo Cine: No hay video.");
-    console.log(`Reintentando... ${window.retries}`);
+    // console.log("Platzi Modo Cine: No hay video.");
+    // console.log(`Reintentando... ${window.retries}`);
     if (window.retries <= 3) {
-      console.log("llamando Start setTimeout");
       window.retries += 1;
-      setTimeout(() => {
-        console.log(`Platzi Modo Cine: Retrying... ${window.retries}`);
-        start();
-      }, 1000);
+      setTimeout(() => start(), 1000);
     }
   }
 }
-//

--- a/README.md
+++ b/README.md
@@ -5,6 +5,17 @@
 
 ## Agrega un botón al reproductor para cambiar a modo cine estilo YouTube en pantallas grandes.
 
+## Ahora soporte nuevo Home!!!
+
+![](./img-example/example_new_home.gif)
+
+## Mejoras en nueva version
+
+- Se mantiene la opción de modo cine incluso en el cambio automatico de videos
+- Se guarda el estado de modo Cine en el `localStorage`
+
+## Retrocompatibilidad con version anterior
+
 <a href="https://youtu.be/hIFga-stWig">
 <img src="https://i.imgur.com/ST7YSZ1.gif" alt="Ejemplo del modo cine"/>
 </a>
@@ -16,3 +27,4 @@ El _modo cine_ es útil cuando se quiere ver el reproductor de video al 100% del
 La puedes descargar como extensión de Google Chrome desde <a href="https://chrome.google.com/webstore/detail/platzi-modo-cine/lbnocnbkjpigeicchmalljbafbfhfhjl">este vínculo.</a>
 
 Al instalarla solo tienes que refrescar la página con el reproductor de la clase y el botón aparecerá en los controles de este.
+

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,8 @@
     "manifest_version": 3,
     "name": "Platzi Modo Cine",
     "description": "Agrega un modo cine al reproductor de Platzi",
-    "version": "1.0",
+    "permissions": ["activeTab"],
+    "version": "2.0",
     "icons": {
         "16": "./images/icon16.png",
         "48": "./images/icon48.png",
@@ -13,10 +14,12 @@
             "16": "./images/icon16.png",
             "48": "./images/icon48.png",
             "128": "./images/icon128.png"
-        }
+        },
+        "default_popup": "./popup.html"
     },
     "content_scripts": [{
-        "matches": ["https://platzi.com/clases/*"],
-        "js": ["./PlatziModoCine.js"]
-    }]
+        "matches": ["https://platzi.com/*"],
+        "js": ["./PlatziModoCine.js"],
+        "run_at": "document_idle"
+    }]    
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
     "manifest_version": 3,
-    "name": "Platzi Modo Cine",
+    "name": "Platzi Modo Cine v2",
     "description": "Agrega un modo cine al reproductor de Platzi",
     "permissions": ["activeTab"],
     "version": "2.0",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,6 @@
     "manifest_version": 3,
     "name": "Platzi Modo Cine v2",
     "description": "Agrega un modo cine al reproductor de Platzi",
-    "permissions": ["activeTab"],
     "version": "2.0",
     "icons": {
         "16": "./images/icon16.png",

--- a/popup.html
+++ b/popup.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Document</title>
+   <style>
+        body {
+            width: 200px;
+            padding: 10px;
+            background-color: #000000;
+            color: white;
+        }
+    </style>
+</head>
+<body>
+  <h1>Platzi Modo Cine</h1>  
+  <h3>By AdalZanabria & Kerkox (Paul Cortes)</h3>
+</body>
+</html>


### PR DESCRIPTION
Se agrega soporte a la nueva version de Platzi para implementar el mismo comportamiento 

Tambien se da soporte para que el estado del modo cine sea persistido y mantenerlo a lo largo de los videos e incluso al cerrar y abrir el navegador
